### PR TITLE
compatibility mode meta tag

### DIFF
--- a/glri-catalog-ui/src/main/webapp/index.jsp
+++ b/glri-catalog-ui/src/main/webapp/index.jsp
@@ -8,6 +8,7 @@
 		%>
         <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" /> <%-- Bootstrap mobile scaling directive --%>
+        <meta http-equiv="X-UA-Compatible" content="chrome=IE8">
 
 		<link href="${pageScope.rootPath}/favicon.ico" rel="shortcut icon" type="image/x-icon" />
 		


### PR DESCRIPTION
Added the suggested meta tag to index.jsp to avoid site rendering in IE compatibility mode, which destroys the apps layout