### PR TITLE
Bug Fix: New project service adds record twice

### DIFF
--- a/glri-catalog-ui/src/main/java/gov/usgs/cida/glri/sb/ui/sbapi/ScienceBaseProjectService.java
+++ b/glri-catalog-ui/src/main/java/gov/usgs/cida/glri/sb/ui/sbapi/ScienceBaseProjectService.java
@@ -76,7 +76,7 @@ public class ScienceBaseProjectService extends HttpServlet {
 				
 				//If the request failed, retry using the service login.
 				//This handles the case where user is not individually authorized to add records
-				if (true || sbreply.has("errors") || !sbreply.has("id") || sbreply.getString("id") == null || sbreply.getString("id").length() < 4) {
+				if (sbreply.has("errors") || !sbreply.has("id") || sbreply.getString("id") == null || sbreply.getString("id").length() < 4) {
 					
 					String username = AppConfig.get(AppConfig.SCIENCEBASE_GLRI_COMMUNITY_USR);
 					String password = AppConfig.get(AppConfig.SCIENCEBASE_GLRI_COMMUNITY_PWD);


### PR DESCRIPTION
The 1st attempt is with the user's credentials, the 2nd attempt as the service login would always happen because of hard-wired logic. The 2nd attempt always seems to fail for me (perhaps some sort of ScienceBase duplicate detection?).  While this bug has been in place, user’s who would normally be able to add records (those w/ admin privileges on the GLRI Community) would have seen additions appear to fail even though the record was created in SB.

I'm guessing I had added that 'true' logic to do testing of the service login and accidentally checked it in.