### PR TITLE
initial set of changes

### DIFF
--- a/glri-catalog-ui/src/main/webapp/js/app/projects.js
+++ b/glri-catalog-ui/src/main/webapp/js/app/projects.js
@@ -422,6 +422,12 @@ GLRICatalogApp.service('Projects',
 		var tags = buildTags(data);
 		var contacts = buildContacts(data);
 		
+		var id = "";
+		
+		if (data.id) {
+			id = '"id": "' +data.id+ '",';
+		}
+		
 		var endDate   = "";
 		if (data.endDate) { // TODO validation after start and year or full date
 			endDate =
@@ -444,7 +450,7 @@ GLRICatalogApp.service('Projects',
 		
 		var newProject =
 		'{'+
-		    '"title": "' +data.title+ '",'+
+			id + '"title": "' +data.title+ '",'+
 		    '"summary": "",'+
 		    '"body": "' +body+ '",'+
 		    '"purpose": "' +data.purpose+ '",'+
@@ -483,7 +489,8 @@ GLRICatalogApp.service('Projects',
 		var glriProj = {
 			title: sbProj.title,
 			purpose: sbProj.purpose,
-			status: sbProj.facets[0].projectStatus
+			status: sbProj.facets[0].projectStatus,
+			id: sbProj.id
 		}
 		
 		//find thumbnail

--- a/glri-catalog-ui/src/main/webapp/templates/contentProjectDetail.html
+++ b/glri-catalog-ui/src/main/webapp/templates/contentProjectDetail.html
@@ -1,6 +1,9 @@
 <div id="contentBrowseDetail" class="clearfix">
 		
 	<h2 class="detailTitle" ng-bind-html="status.currentItem.title"></h2>
+	<div class="edit-link" ng-if="status.currentItem.userCanEdit">
+		<a class="btn btn-small" title="Because you have a role on this project, you may edit it.  Click to edit" prevent-default href="javascript:void(0)" ng-click="nav.setPath('Projects/' + status.currentItem.id)">Edit this Project</a>
+	</div>
 	<img class="browse-image" ng-src="{{status.currentItem.browseImage}}"/>
 	<div class="template-list">
 		<h5>Template<span ng-if="status.currentItem.templates && status.currentItem.templates.length>1">s</span>:


### PR DESCRIPTION
I think this is pretty close to functionally correct as it stands.  The service now detects if a project is an update by looking for an id.  In addition to the changes expected for this task, I had to tweak a few things in the UI code:

* In project.js the project id is now copied back and forth as needed for updated projects
* Added an edit link in the contentProjectDetail.html

NOTE:  All testing was done from the Search tab, not the Project list.

Outstanding issues:
* Permissions are not enforced (this is a separate task)
* Updates currently fail and the actual error is obscured

To see the update errors coming back from ScienceBase, put a breakpoint in the ScienceBaseRestClient:227