### PR TITLE
Removed uses-analytics from project and updated template version instead

### DIFF
--- a/glri-catalog-ui/pom.xml
+++ b/glri-catalog-ui/pom.xml
@@ -160,7 +160,7 @@
 		<dependency>
 			<groupId>gov.usgs.cida.jslibs</groupId>
 			<artifactId>usgs-template</artifactId>
-			<version>2.2</version>
+			<version>2.4</version>
 			<type>war</type>
 		</dependency>
 

--- a/glri-catalog-ui/src/main/webapp/index.jsp
+++ b/glri-catalog-ui/src/main/webapp/index.jsp
@@ -49,7 +49,6 @@
 		<script type="text/javascript" src="./js/app/projects.js"></script>
 		
 		<script type="text/javascript" src="./js/app/cida-analytics.js"></script>
-		<script type="application/javascript" src="https://www2.usgs.gov/scripts/analytics/usgs-analytics.js"></script>
 
 		<!-- Twitter Bootstrap & theme-->
 		<link rel="stylesheet" type="text/css" href="./webjars/bootstrap/${bootstrap.version}/css/bootstrap.css">


### PR DESCRIPTION
Fixed an initial mistake on this task:
I had previously changed the USGS analytics url in the project.  It turns out that the project script reference duplicates the uses-template imported reference.  I removed the project reference and upgraded to a more recent version of our usgs template.